### PR TITLE
Replacement scan for read_gsheet

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,17 +1,17 @@
 # TODO
 
 ## Copy to
-- header
-- sheet
-- types
-- implicit copy to when it sees a gsheets url
-- warn when more than 2048 rows
-- support > 2048 rows
+- [ ] header
+- [ ] sheet
+- [ ] types
+- [ ] implicit copy to when it sees a gsheets url
+- [ ] warn when more than 2048 rows
+- [ ] support > 2048 rows
 
 ## read_gsheet()
-- types
-- large sheets
-- implicit read_gsheet when it sees a gsheets url
+- [ ] types
+- [x] large sheets
+- [x] implicit read_gsheet when it sees a gsheets url
 
 ## Tests
 - Tests for read_gsheet()


### PR DESCRIPTION
Previously you had to 

```sql
FROM read_gsheet('https://docs.google.com/spreadsheets/d/11QdEasMWbETbFVxry-SsD8jVcdYIT1zBQszcF84MdE8/edit?gid=0#gid=0')
```



This allows you to read from a sheet implicitly with

```sql
FROM 'https://docs.google.com/spreadsheets/d/11QdEasMWbETbFVxry-SsD8jVcdYIT1zBQszcF84MdE8/edit?gid=0#gid=0'
```

if the url starts with "https://docs.google.com/spreadsheets/d/"